### PR TITLE
Remove build-essential

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,13 +7,17 @@ ADD collectd.conf /etc/collectd/
 ADD entrypoint.sh /entrypoint.sh
 
 RUN echo 'ef97838e249814ad96a2edc0410326efbb4f3d08  collectd-5.5.0.tar.bz2' > /tmp/collectd.sig && \
-    apt-get update && \
-    apt-get install -y build-essential wget tar lbzip2 && \
+    apt-get update && apt-get install -y build-essential wget tar lbzip2 && \
     wget https://collectd.org/files/collectd-$COLLECTD_VERSION.tar.bz2 && \
     shasum -a 1 -c /tmp/collectd.sig && \
     tar xf collectd-$COLLECTD_VERSION.tar.bz2 && \
     cd collectd-$COLLECTD_VERSION && \
-    ./configure && make && make install && \
-    rm -rf /usr/src/collectd-$COLLECTD_VERSION* /var/lib/apt/lists/*
+    ./configure && make && make install && cd - \
+    rm -rf /usr/src/collectd /usr/src/collectd-$COLLECTD_VERSION* /var/lib/apt/lists/* && \
+    apt-get autoremove -y build-essential 
+
+# todo: remove build-essential
+# or is it something else?
+# just test out in a debian:jessie contianer
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,10 +14,6 @@ RUN echo 'ef97838e249814ad96a2edc0410326efbb4f3d08  collectd-5.5.0.tar.bz2' > /t
     cd collectd-$COLLECTD_VERSION && \
     ./configure && make && make install && cd - \
     rm -rf /usr/src/collectd /usr/src/collectd-$COLLECTD_VERSION* /var/lib/apt/lists/* && \
-    apt-get autoremove -y build-essential 
-
-# todo: remove build-essential
-# or is it something else?
-# just test out in a debian:jessie contianer
+    apt-get autoremove -y build-essential   
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
This drops the image down to `216.4 MB`
